### PR TITLE
fix(tsconfig): 修复z-paging库的TS类型丢失

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       "@dcloudio/types",
       "@uni-helper/uni-types",
       "@types/wechat-miniprogram",
-      "wot-design-uni/global.d.ts"
+      "wot-design-uni/global.d.ts",
+      "z-paging/types"
     ]
   },
   "vueCompilerOptions": {


### PR DESCRIPTION
修复z-paging组件的类型丢失，参阅 [z-paging-TypeScript 支持](https://z-paging.zxlee.cn/start/typescript-support.html#typescript-%E6%94%AF%E6%8C%81)

### **before:**
<img width="565" alt="image" src="https://github.com/user-attachments/assets/5e8ae3a4-bbfb-46a5-bd25-048942d610f9" />


### **after:**
<img width="689" alt="image" src="https://github.com/user-attachments/assets/486982a6-8f2b-4c1d-bac6-d90baeb6459f" />

