### PR TITLE
fix: 修复<text>自动换行导致存在空格的问题

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,15 @@ export default uniHelper({
     'jsdoc/require-returns-description': 'off',
     'ts/no-empty-object-type': 'off',
     'no-extend-native': 'off',
+    'vue/singleline-html-element-content-newline': [
+      'error',
+      {
+        ignoreWhenNoAttributes: true,
+        ignoreWhenEmpty: true,
+        ignores: ['pre', 'textarea', 'text'],
+        externalIgnores: [],
+      },
+    ],
   },
   formatters: {
     /**


### PR DESCRIPTION
修复换行引起的span前存在空格的问题，由于<text>非html标准标签，导致不能像span一样保持单行，添加忽略即可解决