### PR TITLE
Increase Node.js memory limit in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -6,3 +6,4 @@ auto-install-peers=true
 shamefully-hoist=true
 ignore-workspace-root-check=true
 install-workspace-root=true
+node-options=--max-old-space-size=8192


### PR DESCRIPTION
fix  FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory