### PR TITLE
chore(tsconfig): 更新 moduleResolution: node -> bundler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     "composite": true,
     "lib": ["esnext", "dom"],
     "baseUrl": ".",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "paths": {
       "@/*": ["./src/*"],
       "@img/*": ["./src/static/*"]


### PR DESCRIPTION
node 无法理解 package.json 中的 "exports" 字段。 

这是 node 和 bunder 的区别：https://gemini.google.com/share/dc03e2a93e32

bunder 也是 TypeScript 5.x 推荐的

更新后，运行 type-check 命令, 没有发现新增了类型报错，打包正常运行