### PR TITLE
fix: wot-design-uni 基于 vite 配置自动引入组件时，无法正常引入

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,6 +91,13 @@ export default defineConfig(({ command, mode }) => {
       UniKuRoot({
         excludePages: ['**/components/**/**.*'],
       }),
+      // Components 需要在 Uni 之前引入
+      Components({
+        extensions: ['vue'],
+        deep: true, // 是否递归扫描子目录，
+        directoryAsNamespace: false, // 是否把目录名作为命名空间前缀，true 时组件名为 目录名+组件名，
+        dts: 'src/types/components.d.ts', // 自动生成的组件类型声明文件路径（用于 TypeScript 支持）
+      }),
       Uni(),
       {
         // 临时解决 dcloudio 官方的 @dcloudio/uni-mp-compiler 出现的编译 BUG
@@ -139,12 +146,6 @@ export default defineConfig(({ command, mode }) => {
         },
       ),
       syncManifestPlugin(),
-      Components({
-        extensions: ['vue'],
-        deep: true, // 是否递归扫描子目录，
-        directoryAsNamespace: false, // 是否把目录名作为命名空间前缀，true 时组件名为 目录名+组件名，
-        dts: 'src/types/components.d.ts', // 自动生成的组件类型声明文件路径（用于 TypeScript 支持）
-      }),
       // 自动打开开发者工具插件 (必须修改 .env 文件中的 VITE_WX_APPID)
       openDevTools(),
     ],


### PR DESCRIPTION
[相关文档](https://wot-ui.cn/guide/quick-use.html#%E5%9F%BA%E4%BA%8E-vite-%E9%85%8D%E7%BD%AE%E8%87%AA%E5%8A%A8%E5%BC%95%E5%85%A5%E7%BB%84%E4%BB%B6%E6%96%B9%E6%A1%88-2)

<img width="759" height="528" alt="image" src="https://github.com/user-attachments/assets/6b24ce53-34d7-42e7-b557-eb588b7ec302" />

