### PR TITLE
fix: 修复部分 ts/js 文件没有被 ts server include

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,22 @@
   "vueCompilerOptions": {
     "plugins": ["@uni-helper/uni-types/volar-plugin"]
   },
-  "exclude": ["node_modules", "dist", "eslint.config.mjs"]
+  "include": [
+    "package.json",
+    "src/**/*.ts",
+    "src/**/*.js",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.jsx",
+    "src/**/*.vue",
+    "src/**/*.json",
+    "vite.config.ts",
+    "pages.config.ts",
+    "manifest.config.ts",
+    "uno.config.ts",
+    "openapi-ts-request.config.ts",
+    "scripts/**/*.js",
+    "vite-plugins/**/*.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
开发过程中，经常发现根目录下的 `manifest.config.ts`、`vite.config.ts`、`pages.config.ts` 等文件没有 ts 类型提示，需要运行 vs 的『重新加载窗口』命令后才正常。应该是因为这些文件没有被 `ts server` 包含。

**最快复现步聚**：
1. vscode 只打开一个 `vue `文件（如果打开的是 ts 文件， 则无法复现，可能 ts 对这种没有被 include 的文件， 会有回退方案，但 Vue Language Tools 影响了它）
2. 运行 vs 的『重新加载窗口』命令
3. 打开 `manifest.config.ts`，把鼠标放 `defineManifestConfig` 函数上，可以发现没有 ts 类型提示
