### PR TITLE
fix: 微信开发者工具自动启动失败，CLI 参数 -o 改为 open --project

### DIFF
--- a/scripts/open-dev-tools.js
+++ b/scripts/open-dev-tools.js
@@ -35,7 +35,7 @@ function _openDevTools(env = 'dev', options = {}) {
     // macOS
     if (UNI_PLATFORM === 'mp-weixin') {
       const cliPath = wechatDevtoolsCliPath || '/Applications/wechatwebdevtools.app/Contents/MacOS/cli'
-      command = `"${cliPath}" -o "${projectPath}"`
+      command = `"${cliPath}" open --project "${projectPath}"`
     }
     else if (UNI_PLATFORM === 'mp-alipay') {
       command = `/Applications/小程序开发者工具.app/Contents/MacOS/小程序开发者工具 --p "${projectPath}"`
@@ -48,7 +48,7 @@ function _openDevTools(env = 'dev', options = {}) {
     // Windows
     if (UNI_PLATFORM === 'mp-weixin') {
       const cliPath = wechatDevtoolsCliPath || 'C:\\Program Files (x86)\\Tencent\\微信web开发者工具\\cli.bat'
-      command = `"${cliPath}" -o "${projectPath}"`
+      command = `"${cliPath}" open --project "${projectPath}"`
     }
   }
   else {


### PR DESCRIPTION
新版微信开发者工具 CLI 要求使用子命令格式：cli.bat open --project <path>

旧版 -o 参数格式已不兼容，导致 writeBundle 钩子触发时报 "× initialize" 错误，IDE 无法自动启动。

修改内容：macOS 和 Windows 两处 CLI 命令参数
